### PR TITLE
Change git repo url from SSH to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 Please install SAM 2 on a GPU machine using:
 
 ```bash
-git clone git@github.com:facebookresearch/segment-anything-2.git
+git clone https://github.com/facebookresearch/segment-anything-2.git
 
 cd segment-anything-2; pip install -e .
 ```


### PR DESCRIPTION
The change is made for researchers to easly clone the project to check out from systems and platforms with SSH not in sync with github. Eg : Google Colab, Remote GPU Servers etc