### PR TITLE
Add Multiple CUDA Compute Capabilities Support

### DIFF
--- a/install_multiple_compute_capabilities.sh
+++ b/install_multiple_compute_capabilities.sh
@@ -1,0 +1,4 @@
+export CUDA_ARCHITECTURES="70;75;80;86;89;90"
+export SAM2_CUDA_ARCHITECTURES=${CUDA_ARCHITECTURES}
+
+pip install --verbose .


### PR DESCRIPTION
Add support for running SAM-2 using multiple types of GPUs (various CUDA compute capabilities GPUs), by specifying the desired compute capabilities in the `CUDA_ARCHITECTURES` variable in `install_multiple_compute_capabilities.sh`
