### PR TITLE
Fix typo in `connected_components.cu`

### DIFF
--- a/sam2/csrc/connected_components.cu
+++ b/sam2/csrc/connected_components.cu
@@ -210,7 +210,7 @@ __global__ void final_counting(
 
 } // namespace cc2d
 
-std::vector<torch::Tensor> get_connected_componnets(
+std::vector<torch::Tensor> get_connected_components(
     const torch::Tensor& inputs) {
   AT_ASSERTM(inputs.is_cuda(), "inputs must be a CUDA tensor");
   AT_ASSERTM(inputs.ndimension() == 4, "inputs must be [N, 1, H, W] shape");
@@ -283,7 +283,7 @@ std::vector<torch::Tensor> get_connected_componnets(
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def(
-      "get_connected_componnets",
-      &get_connected_componnets,
-      "get_connected_componnets");
+      "get_connected_components",
+      &get_connected_components,
+      "get_connected_components");
 }

--- a/sam2/utils/misc.py
+++ b/sam2/utils/misc.py
@@ -60,7 +60,7 @@ def get_connected_components(mask):
     """
     from sam2 import _C
 
-    return _C.get_connected_componnets(mask.to(torch.uint8).contiguous())
+    return _C.get_connected_components(mask.to(torch.uint8).contiguous())
 
 
 def mask_to_box(masks: torch.Tensor):


### PR DESCRIPTION
* Typo: `get_connected_componnets` -> `get_connected_components`