### PR TITLE
Integrate with Hugging Face

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,11 @@ For promptable segmentation and tracking in videos, we provide a video predictor
 
 ```python
 import torch
-from sam2.sam2_video_predictor import SAM2VideoPredictor
+from sam2.build_sam import build_sam2_video_predictor
 
-predictor = SAM2VideoPredictor.from_pretrained("facebook/sam2-hiera-large")
+checkpoint = "./checkpoints/sam2_hiera_large.pt"
+model_cfg = "sam2_hiera_l.yaml"
+predictor = build_sam2_video_predictor(model_cfg, checkpoint)
 
 with torch.inference_mode(), torch.autocast("cuda", dtype=torch.bfloat16):
     state = predictor.init_state(<your_video>)

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Please refer to the examples in [video_predictor_example.ipynb](./notebooks/vide
 
 ## Load from Hugging Face
 
-Alternatively, models can also be loaded from Hugging Face using the `from_pretrained` method:
+Alternatively, models can also be loaded from [Hugging Face](https://huggingface.co/models?search=facebook/sam2) (requires `pip install huggingface_hub`).
 
 For image prediction:
 

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ cd checkpoints
 
 or individually from:
 
-- [sam2_hiera_tiny.pt](https://dl.fbaipublicfiles.com/segment_anything_2/072824/sam2_hiera_tiny.pt)
-- [sam2_hiera_small.pt](https://dl.fbaipublicfiles.com/segment_anything_2/072824/sam2_hiera_small.pt)
-- [sam2_hiera_base_plus.pt](https://dl.fbaipublicfiles.com/segment_anything_2/072824/sam2_hiera_base_plus.pt)
-- [sam2_hiera_large.pt](https://dl.fbaipublicfiles.com/segment_anything_2/072824/sam2_hiera_large.pt)
+- [sam2_hiera_tiny.pt](https://huggingface.co/facebook/sam2-hiera-tiny)
+- [sam2_hiera_small.pt](https://huggingface.co/facebook/sam2-hiera-small)
+- [sam2_hiera_base_plus.pt](https://huggingface.co/facebook/sam2-hiera-base-plus)
+- [sam2_hiera_large.pt](https://huggingface.co/facebook/sam2-hiera-large)
 
 Then SAM 2 can be used in a few lines as follows for image and video prediction.
 

--- a/README.md
+++ b/README.md
@@ -127,8 +127,14 @@ from sam2.sam2_video_predictor import SAM2VideoPredictor
 predictor = SAM2VideoPredictor.from_pretrained("facebook/sam2-hiera-large")
 
 with torch.inference_mode(), torch.autocast("cuda", dtype=torch.bfloat16):
-    predictor.set_image(<your_image>)
-    masks, _, _ = predictor.predict(<input_prompts>)
+    state = predictor.init_state(<your_video>)
+
+    # add new prompts and instantly get the output on the same frame
+    frame_idx, object_ids, masks = predictor.add_new_points(state, <your_prompts>):
+
+    # propagate the prompts to get masklets throughout the video
+    for frame_idx, object_ids, masks in predictor.propagate_in_video(state):
+        ...
 ```
 
 ## Model Description

--- a/README.md
+++ b/README.md
@@ -60,12 +60,9 @@ SAM 2 has all the capabilities of [SAM](https://github.com/facebookresearch/segm
 
 ```python
 import torch
-from sam2.build_sam import build_sam2
 from sam2.sam2_image_predictor import SAM2ImagePredictor
 
-checkpoint = "./checkpoints/sam2_hiera_large.pt"
-model_cfg = "sam2_hiera_l.yaml"
-predictor = SAM2ImagePredictor(build_sam2(model_cfg, checkpoint))
+predictor = SAM2ImagePredictor.from_pretrained("facebook/sam2-hiera-large")
 
 with torch.inference_mode(), torch.autocast("cuda", dtype=torch.bfloat16):
     predictor.set_image(<your_image>)
@@ -82,11 +79,9 @@ For promptable segmentation and tracking in videos, we provide a video predictor
 
 ```python
 import torch
-from sam2.build_sam import build_sam2_video_predictor
+from sam2.sam2_video_predictor import SAM2VideoPredictor
 
-checkpoint = "./checkpoints/sam2_hiera_large.pt"
-model_cfg = "sam2_hiera_l.yaml"
-predictor = build_sam2_video_predictor(model_cfg, checkpoint)
+predictor = SAM2VideoPredictor.from_pretrained("facebook/sam2-hiera-large")
 
 with torch.inference_mode(), torch.autocast("cuda", dtype=torch.bfloat16):
     state = predictor.init_state(<your_video>)

--- a/README.md
+++ b/README.md
@@ -60,6 +60,22 @@ SAM 2 has all the capabilities of [SAM](https://github.com/facebookresearch/segm
 
 ```python
 import torch
+from sam2.build_sam import build_sam2
+from sam2.sam2_image_predictor import SAM2ImagePredictor
+
+checkpoint = "./checkpoints/sam2_hiera_large.pt"
+model_cfg = "sam2_hiera_l.yaml"
+predictor = SAM2ImagePredictor(build_sam2(model_cfg, checkpoint))
+
+with torch.inference_mode(), torch.autocast("cuda", dtype=torch.bfloat16):
+    predictor.set_image(<your_image>)
+    masks, _, _ = predictor.predict(<input_prompts>)
+```
+
+or from Hugging Face, as follows:
+
+```python
+import torch
 from sam2.sam2_image_predictor import SAM2ImagePredictor
 
 predictor = SAM2ImagePredictor.from_pretrained("facebook/sam2-hiera-large")
@@ -92,6 +108,19 @@ with torch.inference_mode(), torch.autocast("cuda", dtype=torch.bfloat16):
     # propagate the prompts to get masklets throughout the video
     for frame_idx, object_ids, masks in predictor.propagate_in_video(state):
         ...
+```
+
+or from Hugging Face, as follows:
+
+```python
+import torch
+from sam2.sam2_video_predictor import SAM2VideoPredictor
+
+predictor = SAM2VideoPredictor.from_pretrained("facebook/sam2-hiera-large")
+
+with torch.inference_mode(), torch.autocast("cuda", dtype=torch.bfloat16):
+    predictor.set_image(<your_image>)
+    masks, _, _ = predictor.predict(<input_prompts>)
 ```
 
 Please refer to the examples in [video_predictor_example.ipynb](./notebooks/video_predictor_example.ipynb) for details on how to add prompts, make refinements, and track multiple objects in videos.

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ cd checkpoints
 
 or individually from:
 
-- [sam2_hiera_tiny.pt](https://huggingface.co/facebook/sam2-hiera-tiny)
-- [sam2_hiera_small.pt](https://huggingface.co/facebook/sam2-hiera-small)
-- [sam2_hiera_base_plus.pt](https://huggingface.co/facebook/sam2-hiera-base-plus)
-- [sam2_hiera_large.pt](https://huggingface.co/facebook/sam2-hiera-large)
+- [sam2_hiera_tiny.pt](https://dl.fbaipublicfiles.com/segment_anything_2/072824/sam2_hiera_tiny.pt)
+- [sam2_hiera_small.pt](https://dl.fbaipublicfiles.com/segment_anything_2/072824/sam2_hiera_small.pt)
+- [sam2_hiera_base_plus.pt](https://dl.fbaipublicfiles.com/segment_anything_2/072824/sam2_hiera_base_plus.pt)
+- [sam2_hiera_large.pt](https://dl.fbaipublicfiles.com/segment_anything_2/072824/sam2_hiera_large.pt)
 
 Then SAM 2 can be used in a few lines as follows for image and video prediction.
 
@@ -99,7 +99,7 @@ with torch.inference_mode(), torch.autocast("cuda", dtype=torch.bfloat16):
 
 Please refer to the examples in [video_predictor_example.ipynb](./notebooks/video_predictor_example.ipynb) for details on how to add prompts, make refinements, and track multiple objects in videos.
 
-## Load from Hugging Face
+## Load from 🤗 Hugging Face
 
 Alternatively, models can also be loaded from [Hugging Face](https://huggingface.co/models?search=facebook/sam2) (requires `pip install huggingface_hub`).
 

--- a/README.md
+++ b/README.md
@@ -72,19 +72,6 @@ with torch.inference_mode(), torch.autocast("cuda", dtype=torch.bfloat16):
     masks, _, _ = predictor.predict(<input_prompts>)
 ```
 
-or from Hugging Face, as follows:
-
-```python
-import torch
-from sam2.sam2_image_predictor import SAM2ImagePredictor
-
-predictor = SAM2ImagePredictor.from_pretrained("facebook/sam2-hiera-large")
-
-with torch.inference_mode(), torch.autocast("cuda", dtype=torch.bfloat16):
-    predictor.set_image(<your_image>)
-    masks, _, _ = predictor.predict(<input_prompts>)
-```
-
 Please refer to the examples in [image_predictor_example.ipynb](./notebooks/image_predictor_example.ipynb) for static image use cases.
 
 SAM 2 also supports automatic mask generation on images just like SAM. Please see [automatic_mask_generator_example.ipynb](./notebooks/automatic_mask_generator_example.ipynb) for automatic mask generation in images.
@@ -110,7 +97,26 @@ with torch.inference_mode(), torch.autocast("cuda", dtype=torch.bfloat16):
         ...
 ```
 
-or from Hugging Face, as follows:
+Please refer to the examples in [video_predictor_example.ipynb](./notebooks/video_predictor_example.ipynb) for details on how to add prompts, make refinements, and track multiple objects in videos.
+
+## Load from Hugging Face
+
+Alternatively, models can also be loaded from Hugging Face using the `from_pretrained` method:
+
+For image prediction:
+
+```python
+import torch
+from sam2.sam2_image_predictor import SAM2ImagePredictor
+
+predictor = SAM2ImagePredictor.from_pretrained("facebook/sam2-hiera-large")
+
+with torch.inference_mode(), torch.autocast("cuda", dtype=torch.bfloat16):
+    predictor.set_image(<your_image>)
+    masks, _, _ = predictor.predict(<input_prompts>)
+```
+
+For video prediction:
 
 ```python
 import torch
@@ -122,8 +128,6 @@ with torch.inference_mode(), torch.autocast("cuda", dtype=torch.bfloat16):
     predictor.set_image(<your_image>)
     masks, _, _ = predictor.predict(<input_prompts>)
 ```
-
-Please refer to the examples in [video_predictor_example.ipynb](./notebooks/video_predictor_example.ipynb) for details on how to add prompts, make refinements, and track multiple objects in videos.
 
 ## Model Description
 

--- a/sam2/build_sam.py
+++ b/sam2/build_sam.py
@@ -11,6 +11,8 @@ from hydra import compose
 from hydra.utils import instantiate
 from omegaconf import OmegaConf
 
+from huggingface_hub import hf_hub_download
+
 
 def build_sam2(
     config_file,
@@ -74,6 +76,18 @@ def build_sam2_video_predictor(
     if mode == "eval":
         model.eval()
     return model
+
+
+def build_sam2_hf(model_id, **kwargs):
+    config_file = hf_hub_download(repo_id=model_id, filename=f"{model_id}.yaml")
+    ckpt_path = hf_hub_download(repo_id=model_id, filename=f"{model_id}.pt")
+    return build_sam2_video_predictor(config_file=config_file, ckpt_path=ckpt_path, **kwargs)
+
+
+def build_sam2_video_predictor_hf(model_id, **kwargs):
+    config_file = hf_hub_download(repo_id=model_id, filename=f"{model_id}.yaml")
+    ckpt_path = hf_hub_download(repo_id=model_id, filename=f"{model_id}.pt")
+    return build_sam2_video_predictor(config_file=config_file, ckpt_path=ckpt_path, **kwargs)
 
 
 def _load_checkpoint(model, ckpt_path):

--- a/sam2/build_sam.py
+++ b/sam2/build_sam.py
@@ -87,9 +87,9 @@ def build_sam2_hf(model_id, **kwargs):
         "facebook/sam2-hiera-large": ("sam2_hiera_l.yaml", "sam2_hiera_large.pt"),
     }
     config_name, checkpoint_name = model_id_to_filenames[model_id]
-    config_file = hf_hub_download(repo_id=model_id, filename=config_name)
+    # config_file = hf_hub_download(repo_id=model_id, filename=config_name)
     ckpt_path = hf_hub_download(repo_id=model_id, filename=checkpoint_name)
-    return build_sam2_video_predictor(config_file=config_file, ckpt_path=ckpt_path, **kwargs)
+    return build_sam2_video_predictor(config_file=config_name, ckpt_path=ckpt_path, **kwargs)
 
 
 def build_sam2_video_predictor_hf(model_id, **kwargs):

--- a/sam2/build_sam.py
+++ b/sam2/build_sam.py
@@ -88,16 +88,22 @@ def build_sam2_hf(model_id, **kwargs):
     }
     config_name, checkpoint_name = model_id_to_filenames[model_id]
     ckpt_path = hf_hub_download(repo_id=model_id, filename=checkpoint_name)
-    return build_sam2_video_predictor(config_file=config_name, ckpt_path=ckpt_path, **kwargs)
+    return build_sam2(config_file=config_name, ckpt_path=ckpt_path, **kwargs)
 
 
 def build_sam2_video_predictor_hf(model_id, **kwargs):
 
     from huggingface_hub import hf_hub_download
 
-    config_file = hf_hub_download(repo_id=model_id, filename=f"{model_id}.yaml")
-    ckpt_path = hf_hub_download(repo_id=model_id, filename=f"{model_id}.pt")
-    return build_sam2_video_predictor(config_file=config_file, ckpt_path=ckpt_path, **kwargs)
+    model_id_to_filenames = {
+        "facebook/sam2-hiera-tiny": ("sam2_hiera_t.yaml", "sam2_hiera_tiny.pt"),
+        "facebook/sam2-hiera-small": ("sam2_hiera_s.yaml", "sam2_hiera_small.pt"),
+        "facebook/sam2-hiera-base-plus": ("sam2_hiera_b+.yaml", "sam2_hiera_base_plus.pt"),
+        "facebook/sam2-hiera-large": ("sam2_hiera_l.yaml", "sam2_hiera_large.pt"),
+    }
+    config_name, checkpoint_name = model_id_to_filenames[model_id]
+    ckpt_path = hf_hub_download(repo_id=model_id, filename=checkpoint_name)
+    return build_sam2_video_predictor(config_file=config_name, ckpt_path=ckpt_path, **kwargs)
 
 
 def _load_checkpoint(model, ckpt_path):

--- a/sam2/build_sam.py
+++ b/sam2/build_sam.py
@@ -83,7 +83,10 @@ def build_sam2_hf(model_id, **kwargs):
     model_id_to_filenames = {
         "facebook/sam2-hiera-tiny": ("sam2_hiera_t.yaml", "sam2_hiera_tiny.pt"),
         "facebook/sam2-hiera-small": ("sam2_hiera_s.yaml", "sam2_hiera_small.pt"),
-        "facebook/sam2-hiera-base-plus": ("sam2_hiera_b+.yaml", "sam2_hiera_base_plus.pt"),
+        "facebook/sam2-hiera-base-plus": (
+            "sam2_hiera_b+.yaml",
+            "sam2_hiera_base_plus.pt",
+        ),
         "facebook/sam2-hiera-large": ("sam2_hiera_l.yaml", "sam2_hiera_large.pt"),
     }
     config_name, checkpoint_name = model_id_to_filenames[model_id]
@@ -98,12 +101,17 @@ def build_sam2_video_predictor_hf(model_id, **kwargs):
     model_id_to_filenames = {
         "facebook/sam2-hiera-tiny": ("sam2_hiera_t.yaml", "sam2_hiera_tiny.pt"),
         "facebook/sam2-hiera-small": ("sam2_hiera_s.yaml", "sam2_hiera_small.pt"),
-        "facebook/sam2-hiera-base-plus": ("sam2_hiera_b+.yaml", "sam2_hiera_base_plus.pt"),
+        "facebook/sam2-hiera-base-plus": (
+            "sam2_hiera_b+.yaml",
+            "sam2_hiera_base_plus.pt",
+        ),
         "facebook/sam2-hiera-large": ("sam2_hiera_l.yaml", "sam2_hiera_large.pt"),
     }
     config_name, checkpoint_name = model_id_to_filenames[model_id]
     ckpt_path = hf_hub_download(repo_id=model_id, filename=checkpoint_name)
-    return build_sam2_video_predictor(config_file=config_name, ckpt_path=ckpt_path, **kwargs)
+    return build_sam2_video_predictor(
+        config_file=config_name, ckpt_path=ckpt_path, **kwargs
+    )
 
 
 def _load_checkpoint(model, ckpt_path):

--- a/sam2/build_sam.py
+++ b/sam2/build_sam.py
@@ -11,8 +11,6 @@ from hydra import compose
 from hydra.utils import instantiate
 from omegaconf import OmegaConf
 
-from huggingface_hub import hf_hub_download
-
 
 def build_sam2(
     config_file,
@@ -80,6 +78,8 @@ def build_sam2_video_predictor(
 
 def build_sam2_hf(model_id, **kwargs):
 
+    from huggingface_hub import hf_hub_download
+
     model_id_to_filenames = {
         "facebook/sam2-hiera-tiny": ("sam2_hiera_t.yaml", "sam2_hiera_tiny.pt"),
         "facebook/sam2-hiera-small": ("sam2_hiera_s.yaml", "sam2_hiera_small.pt"),
@@ -87,12 +87,14 @@ def build_sam2_hf(model_id, **kwargs):
         "facebook/sam2-hiera-large": ("sam2_hiera_l.yaml", "sam2_hiera_large.pt"),
     }
     config_name, checkpoint_name = model_id_to_filenames[model_id]
-    # config_file = hf_hub_download(repo_id=model_id, filename=config_name)
     ckpt_path = hf_hub_download(repo_id=model_id, filename=checkpoint_name)
     return build_sam2_video_predictor(config_file=config_name, ckpt_path=ckpt_path, **kwargs)
 
 
 def build_sam2_video_predictor_hf(model_id, **kwargs):
+
+    from huggingface_hub import hf_hub_download
+
     config_file = hf_hub_download(repo_id=model_id, filename=f"{model_id}.yaml")
     ckpt_path = hf_hub_download(repo_id=model_id, filename=f"{model_id}.pt")
     return build_sam2_video_predictor(config_file=config_file, ckpt_path=ckpt_path, **kwargs)

--- a/sam2/build_sam.py
+++ b/sam2/build_sam.py
@@ -79,8 +79,16 @@ def build_sam2_video_predictor(
 
 
 def build_sam2_hf(model_id, **kwargs):
-    config_file = hf_hub_download(repo_id=model_id, filename=f"{model_id}.yaml")
-    ckpt_path = hf_hub_download(repo_id=model_id, filename=f"{model_id}.pt")
+
+    model_id_to_filenames = {
+        "facebook/sam2-hiera-tiny": ("sam2_hiera_t.yaml", "sam2_hiera_tiny.pt"),
+        "facebook/sam2-hiera-small": ("sam2_hiera_s.yaml", "sam2_hiera_small.pt"),
+        "facebook/sam2-hiera-base-plus": ("sam2_hiera_b+.yaml", "sam2_hiera_base_plus.pt"),
+        "facebook/sam2-hiera-large": ("sam2_hiera_l.yaml", "sam2_hiera_large.pt"),
+    }
+    config_name, checkpoint_name = model_id_to_filenames[model_id]
+    config_file = hf_hub_download(repo_id=model_id, filename=config_name)
+    ckpt_path = hf_hub_download(repo_id=model_id, filename=checkpoint_name)
     return build_sam2_video_predictor(config_file=config_file, ckpt_path=ckpt_path, **kwargs)
 
 

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -13,6 +13,7 @@ import torch
 from PIL.Image import Image
 
 from sam2.modeling.sam2_base import SAM2Base
+
 from sam2.utils.transforms import SAM2Transforms
 
 

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -65,7 +65,7 @@ class SAM2ImagePredictor:
     @classmethod
     def from_pretrained(cls, model_id: str, **kwargs) -> "SAM2ImagePredictor":
         """
-        Load a pretrained model from the Hugging Face model hub.
+        Load a pretrained model from the Hugging Face hub.
 
         Arguments:
           model_id (str): The Hugging Face repository ID.

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -62,7 +62,8 @@ class SAM2ImagePredictor:
             (64, 64),
         ]
 
-    def from_pretrained(model_id: str, **kwargs) -> "SAM2ImagePredictor":
+    @classmethod
+    def from_pretrained(cls, model_id: str, **kwargs) -> "SAM2ImagePredictor":
         """
         Load a pretrained model from the Hugging Face model hub.
 
@@ -74,7 +75,7 @@ class SAM2ImagePredictor:
           (SAM2ImagePredictor): The loaded model.
         """
         sam_model = build_sam2_hf(model_id, **kwargs)
-        return SAM2ImagePredictor(sam_model)
+        return cls(sam_model)
 
     @torch.no_grad()
     def set_image(

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -13,7 +13,6 @@ import torch
 from PIL.Image import Image
 
 from sam2.modeling.sam2_base import SAM2Base
-from sam2.build_sam import build_sam2_hf
 from sam2.utils.transforms import SAM2Transforms
 
 
@@ -74,6 +73,8 @@ class SAM2ImagePredictor:
         Returns:
           (SAM2ImagePredictor): The loaded model.
         """
+        from sam2.build_sam import build_sam2_hf
+
         sam_model = build_sam2_hf(model_id, **kwargs)
         return cls(sam_model)
 

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -13,7 +13,7 @@ import torch
 from PIL.Image import Image
 
 from sam2.modeling.sam2_base import SAM2Base
-
+from sam2.build_sam import build_sam2_hf
 from sam2.utils.transforms import SAM2Transforms
 
 
@@ -61,6 +61,20 @@ class SAM2ImagePredictor:
             (128, 128),
             (64, 64),
         ]
+
+    def from_pretrained(model_id: str, **kwargs) -> "SAM2ImagePredictor":
+        """
+        Load a pretrained model from the Hugging Face model hub.
+
+        Arguments:
+          model_id (str): The Hugging Face repository ID.
+          **kwargs: Additional arguments to pass to the model constructor.
+
+        Returns:
+          (SAM2ImagePredictor): The loaded model.
+        """
+        sam_model = build_sam2_hf(model_id, **kwargs)
+        return SAM2ImagePredictor(sam_model)
 
     @torch.no_grad()
     def set_image(

--- a/sam2/sam2_video_predictor.py
+++ b/sam2/sam2_video_predictor.py
@@ -119,7 +119,7 @@ class SAM2VideoPredictor(SAM2Base):
 
         sam_model = build_sam2_video_predictor_hf(model_id, **kwargs)
         return cls(sam_model)
-    
+
     def _obj_id_to_idx(self, inference_state, obj_id):
         """Map client-side object id to model-side object index."""
         obj_idx = inference_state["obj_id_to_idx"].get(obj_id, None)

--- a/sam2/sam2_video_predictor.py
+++ b/sam2/sam2_video_predictor.py
@@ -104,7 +104,7 @@ class SAM2VideoPredictor(SAM2Base):
         return inference_state
 
     @classmethod
-    def from_pretrained(cls, model_id: str, **kwargs) -> "SAM2ImagePredictor":
+    def from_pretrained(cls, model_id: str, **kwargs) -> "SAM2VideoPredictor":
         """
         Load a pretrained model from the Hugging Face model hub.
 
@@ -113,7 +113,7 @@ class SAM2VideoPredictor(SAM2Base):
           **kwargs: Additional arguments to pass to the model constructor.
 
         Returns:
-          (SAM2ImagePredictor): The loaded model.
+          (SAM2VideoPredictor): The loaded model.
         """
         from sam2.build_sam import build_sam2_video_predictor_hf
 

--- a/sam2/sam2_video_predictor.py
+++ b/sam2/sam2_video_predictor.py
@@ -103,6 +103,23 @@ class SAM2VideoPredictor(SAM2Base):
         self._get_image_feature(inference_state, frame_idx=0, batch_size=1)
         return inference_state
 
+    @classmethod
+    def from_pretrained(cls, model_id: str, **kwargs) -> "SAM2ImagePredictor":
+        """
+        Load a pretrained model from the Hugging Face model hub.
+
+        Arguments:
+          model_id (str): The Hugging Face repository ID.
+          **kwargs: Additional arguments to pass to the model constructor.
+
+        Returns:
+          (SAM2ImagePredictor): The loaded model.
+        """
+        from sam2.build_sam import build_sam2_video_predictor_hf
+
+        sam_model = build_sam2_video_predictor_hf(model_id, **kwargs)
+        return cls(sam_model)
+    
     def _obj_id_to_idx(self, inference_state, obj_id):
         """Map client-side object id to model-side object index."""
         obj_idx = inference_state["obj_id_to_idx"].get(obj_id, None)

--- a/sam2/sam2_video_predictor.py
+++ b/sam2/sam2_video_predictor.py
@@ -106,7 +106,7 @@ class SAM2VideoPredictor(SAM2Base):
     @classmethod
     def from_pretrained(cls, model_id: str, **kwargs) -> "SAM2VideoPredictor":
         """
-        Load a pretrained model from the Hugging Face model hub.
+        Load a pretrained model from the Hugging Face hub.
 
         Arguments:
           model_id (str): The Hugging Face repository ID.


### PR DESCRIPTION
This PR fixes #1. It aims to make it possible to load any SAM 2 model directly from the hub.

The checkpoints are already part of the facebook org:
* https://huggingface.co/facebook/sam2-hiera-tiny
* https://huggingface.co/facebook/sam2-hiera-small
* https://huggingface.co/facebook/sam2-hiera-base-plus
* https://huggingface.co/facebook/sam2-hiera-large.

This PR allows to do the following:

```python
from sam2.sam2_image_predictor import SAM2ImagePredictor

predictor = SAM2ImagePredictor.from_pretrained("facebook/sam2-hiera-small")
```

This also ensures that [download stats](https://huggingface.co/docs/hub/models-download-stats) work, meaning you'll be able to see how many times people actually load one of these checkpoints from the hub. This will also allow us to compare to the download stats of Transformers which will be interesting :)

To do:

- [x] update README to link to HF artifacts
- [ ] update notebooks (?)
- [x] support video predictor