### PR TITLE
Update INSTALL.md with CUDA_HOME-related troubleshooting

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -56,6 +56,12 @@ Also, you should make sure
 python -c 'import torch; from torch.utils.cpp_extension import CUDA_HOME; print(torch.cuda.is_available(), CUDA_HOME)'
 ```
 print `(True, a directory with cuda)` to verify that the CUDA toolkits are correctly set up.
+
+If you are still having problems after verifying that the CUDA toolkit is installed and the `CUDA_HOME` environment variable is set properly, you may have to add the `--no-build-isolation` flag to the pip command:
+```
+pip install --no-build-isolation -e .
+```
+
 </details>
 
 <details>


### PR DESCRIPTION
This is referring to https://github.com/facebookresearch/segment-anything-2/issues/137 , which in itself refers to a common problem during installation, mentioned on https://github.com/facebookresearch/segment-anything-2/issues/19 .

Some users may encounter significant trouble installing the project, running into the error `OSError: CUDA_HOME environment variable is not set. Please set it to your CUDA install root.`. Simply adding the `--no-build-isolation` flag to the pip install, e.g. `pip install --no-build-isolation -e .`, usually solves this problem. However, this fix is not mentioned anywhere within the readmes or installation troubleshooting docs. This PR adds this recommendation into the INSTALL.md file under the "My installation failed with `CUDA_HOME environment variable is not set` " section, ensuring that more users are aware of this potential fix.

Examples of users experiencing related difficulties when installing:
https://github.com/facebookresearch/segment-anything-2/issues/19
https://github.com/facebookresearch/segment-anything-2/issues/41
https://github.com/facebookresearch/segment-anything-2/issues/99
https://github.com/facebookresearch/segment-anything-2/issues/133