### PR TITLE
Fix pluralization of 'output level' to 'output levels' in yaml files

### DIFF
--- a/sam2_configs/sam2_hiera_b+.yaml
+++ b/sam2_configs/sam2_hiera_b+.yaml
@@ -20,7 +20,7 @@ model:
         temperature: 10000
       d_model: 256
       backbone_channel_list: [896, 448, 224, 112]
-      fpn_top_down_levels: [2, 3]  # output level 0 and 1 directly use the backbone features
+      fpn_top_down_levels: [2, 3]  # output levels 0 and 1 directly use the backbone features
       fpn_interp_model: nearest
 
   memory_attention:

--- a/sam2_configs/sam2_hiera_l.yaml
+++ b/sam2_configs/sam2_hiera_l.yaml
@@ -24,7 +24,7 @@ model:
         temperature: 10000
       d_model: 256
       backbone_channel_list: [1152, 576, 288, 144]
-      fpn_top_down_levels: [2, 3]  # output level 0 and 1 directly use the backbone features
+      fpn_top_down_levels: [2, 3]  # output levels 0 and 1 directly use the backbone features
       fpn_interp_model: nearest
 
   memory_attention:

--- a/sam2_configs/sam2_hiera_s.yaml
+++ b/sam2_configs/sam2_hiera_s.yaml
@@ -23,7 +23,7 @@ model:
         temperature: 10000
       d_model: 256
       backbone_channel_list: [768, 384, 192, 96]
-      fpn_top_down_levels: [2, 3]  # output level 0 and 1 directly use the backbone features
+      fpn_top_down_levels: [2, 3]  # output levels 0 and 1 directly use the backbone features
       fpn_interp_model: nearest
 
   memory_attention:

--- a/sam2_configs/sam2_hiera_t.yaml
+++ b/sam2_configs/sam2_hiera_t.yaml
@@ -23,7 +23,7 @@ model:
         temperature: 10000
       d_model: 256
       backbone_channel_list: [768, 384, 192, 96]
-      fpn_top_down_levels: [2, 3]  # output level 0 and 1 directly use the backbone features
+      fpn_top_down_levels: [2, 3]  # output levels 0 and 1 directly use the backbone features
       fpn_interp_model: nearest
 
   memory_attention:


### PR DESCRIPTION
Corrected the pluralization of 'output level' to 'output levels' in the following files to accurately reflect the reference to multiple levels:

- sam2_hiera_b+.yaml
- sam2_hiera_l.yaml
- sam2_hiera_s.yaml
- sam2_hiera_t.yaml

This change ensures consistency and clarity in the documentation.