### PR TITLE
fix typographical errors

### DIFF
--- a/sam2/utils/misc.py
+++ b/sam2/utils/misc.py
@@ -68,7 +68,7 @@ def mask_to_box(masks: torch.Tensor):
     compute bounding box given an input mask
 
     Inputs:
-    - masks: [B, 1, H, W] boxes, dtype=torch.Tensor
+    - masks: [B, 1, H, W] masks, dtype=torch.Tensor
 
     Returns:
     - box_coords: [B, 1, 4], contains (x, y) coordinates of top left and bottom right box corners, dtype=torch.Tensor
@@ -120,7 +120,7 @@ class AsyncVideoFrameLoader:
         self.offload_video_to_cpu = offload_video_to_cpu
         self.img_mean = img_mean
         self.img_std = img_std
-        # items in `self._images` will be loaded asynchronously
+        # items in `self.images` will be loaded asynchronously
         self.images = [None] * len(img_paths)
         # catch and raise any exceptions in the async loading thread
         self.exception = None


### PR DESCRIPTION
This PR addresses two main issues identified in the code:

1. Documentation Update in mask_to_box: Corrected the input description from [B, 1, H, W] **boxes** to [B, 1, H, W] **masks** to accurately reflect that the input is masks, not boxes.
2. Variable Name Consistency in AsyncVideoFrameLoader: Updated comments to consistently use `self.images` instead of the previously incorrect ` self._images`. This change ensures clarity and correctness in the asynchronous loading process documentation.