### PR TITLE
Use skimage.measure.label if failed in importing sam2._C module

### DIFF
--- a/sam2/utils/misc.py
+++ b/sam2/utils/misc.py
@@ -58,9 +58,16 @@ def get_connected_components(mask):
     - counts: A tensor of shape (N, 1, H, W) containing the area of the connected
               components for foreground pixels and 0 for background pixels.
     """
-    from sam2 import _C
+    try:
+        from sam2 import _C
 
-    return _C.get_connected_componnets(mask.to(torch.uint8).contiguous())
+        return _C.get_connected_componnets(mask.to(torch.uint8).contiguous())
+    except Exception:
+        import skimage.measure
+
+        return skimage.measure.label(
+            mask.to(torch.uint8).contiguous().cpu().numpy(), return_num=True
+        )
 
 
 def mask_to_box(masks: torch.Tensor):


### PR DESCRIPTION
This PR uses `skimage.measure.label` to calculate connected components when the import of the `sam2._C` module fails. In the original implementation of `cc_torch`, there is an example demonstrating their equivalence.
https://github.com/zsef123/Connected_components_PyTorch/blob/main/example.ipynb