### PR TITLE
Raise error messages for invalid prompts 

### DIFF
--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -397,6 +397,10 @@ class SAM2ImagePredictor:
             # we merge "boxes" and "points" into a single "concat_points" input (where
             # boxes are added at the beginning) to sam_prompt_encoder
             if concat_points is not None:
+                if box_coords.size(0) > 1 or box_labels.size(0) > 1:
+                    raise ValueError("If you use a combination of box and point as a prompt, only a single "
+                                     "combination is supported. Please provide only one combination of box and point.")
+
                 concat_coords = torch.cat([box_coords, concat_points[0]], dim=1)
                 concat_labels = torch.cat([box_labels, concat_points[1]], dim=1)
                 concat_points = (concat_coords, concat_labels)

--- a/sam2/sam2_video_predictor.py
+++ b/sam2/sam2_video_predictor.py
@@ -209,6 +209,10 @@ class SAM2VideoPredictor(SAM2Base):
                     "box prompt must be provided before any point prompt "
                     "(please use clear_old_points=True instead)"
                 )
+            if box.shape[0] > 1:
+                raise ValueError(
+                    "Only one box can be used as a prompt. Please provide a single box."
+                )
             if inference_state["tracking_has_started"]:
                 warnings.warn(
                     "You are adding a box after tracking starts. SAM 2 may not always be "


### PR DESCRIPTION
This PR raises the error message for invalid prompts.

As I understand it (please correct me if I'm wrong)
These prompts cannot be used:

1. Multiple box and points combinataions in `SAM2ImagePredictor.predict()` ( Only single combination is supported )

2. Multiple boxes in `SAM2VideoPredictor.add_new_points_or_box()` ( Only single box is supported )

This is sample code to reproduce errors with these invalid prompts: 

```
import os
import numpy as np
from PIL import Image
from sam2.build_sam import build_sam2, build_sam2_video_predictor
from sam2.sam2_image_predictor import SAM2ImagePredictor

# Set paths
SAM2_CONFIGS_DIR = "path\\to\\configs_directory"
MODELS_DIR = "path\\to\\models_directory"
IMAGE_PATH = "path\\to\\image.jpg"
VIDEO_FRAMES_DIR = "path\\to\\video_frames_directory"

config_path = os.path.join(SAM2_CONFIGS_DIR, "sam2_hiera_l.yaml")
model_path = os.path.join(MODELS_DIR, "sam2_hiera_large.pt")

model = build_sam2(
    config_file=config_path,
    ckpt_path=model_path,
    device="cuda"
)
image_predictor = SAM2ImagePredictor(sam_model=model)
image = Image.open(IMAGE_PATH)
image_predictor.set_image(image)

double_box = np.array([
    [210, 609, 276, 698],
    [308, 425, 357, 501]
])
double_point_coords = np.array([
    [245, 655],
    [324, 456]
])
double_point_labels = np.array([1, 1])

# Using multiple combinations and getting errors
image_predictor.predict(point_coords=double_point_coords,
                        point_labels=double_point_labels,
                        box=double_box)

# Video Predictor case
model = build_sam2_video_predictor(
    config_file=config_path,
    ckpt_path=model_path,
    device="cuda"
)
inference_state = model.init_state(video_path=VIDEO_FRAMES_DIR)

# Using multiple boxes and getting errors
idx, scores, logits = model.add_new_points_or_box(
    frame_idx=0,
    obj_id=0,
    inference_state=inference_state,
    points=None,
    labels=None,
    box=double_box
)
```


