### PR TITLE
README Update with && instead of &

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ SAM 2 needs to be installed first before use. The code requires `python>=3.10`, 
 ```bash
 git clone https://github.com/facebookresearch/segment-anything-2.git
 
-cd segment-anything-2 & pip install -e .
+cd segment-anything-2 && pip install -e .
 ```
 If you are installing on Windows, it's strongly recommended to use [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) with Ubuntu.
 


### PR DESCRIPTION
NIT:
The current command cd segment-anything-2 & pip install -e . should use && instead of &. Using && ensures that the pip install command only runs if the cd command is successful. The & operator runs both commands in parallel, which could lead to issues if the directory change isn't completed before the installation starts.

This change improves the reliability of the script by preventing potential errors from occurring if the cd command fails.