### PR TITLE
Fix the dependencies install command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ SAM 2 needs to be installed first before use. The code requires `python>=3.10`, 
 ```bash
 git clone https://github.com/facebookresearch/segment-anything-2.git
 
-cd segment-anything-2 & pip install -e .
+cd segment-anything-2 && pip install -e .
 ```
 If you are installing on Windows, it's strongly recommended to use [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) with Ubuntu.
 


### PR DESCRIPTION
The current instruction would look for setup.py in the current folder instead of segment-anything-2 folder. 

❌ `cd segment-anything-2 & pip install -e .`
```
Obtaining file:///home/user 
      ERROR: file:///home/user does not appear to be a Python project: neither 'setup.py' nor 'pyproject.toml' found.```
```

✅ `cd segment-anything-2 && pip install -e .`

 ```
Obtaining file:///home/user/segment-anything-2 
           Installing build dependencies ...
```
